### PR TITLE
Buffer records when execting query without block.

### DIFF
--- a/lib/db/client.rb
+++ b/lib/db/client.rb
@@ -24,7 +24,7 @@ require 'async/io'
 require 'async/io/stream'
 require 'async/pool/controller'
 
-require_relative 'context/generic'
+require_relative 'context/transient'
 require_relative 'context/session'
 require_relative 'context/transaction'
 
@@ -50,7 +50,7 @@ module DB
 		
 		# Acquire a generic context which will acquire a connection on demand.
 		def context(**options)
-			context = Context::Generic.new(@pool, **options)
+			context = Context::Transient.new(@pool, **options)
 			
 			return context unless block_given?
 			

--- a/lib/db/context/session.rb
+++ b/lib/db/context/session.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright, 2020, by Samuel G. D. Williams. <http://www.codeotaku.com>
+# Copyright, 2021, by Samuel G. D. Williams. <http://www.codeotaku.com>
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,11 +21,51 @@
 # THE SOFTWARE.
 
 require_relative '../query'
+require_relative '../records'
 
 module DB
 	module Context
 		# A connected context for sending queries and reading results.
-		class Session < Generic
+		class Session
+			# Initialize the query context attached to the given connection pool.
+			def initialize(pool, **options)
+				@pool = pool
+				@connection = nil
+			end
+			
+			def connection?
+				@connection != nil
+			end
+			
+			# Lazy initialize underlying connection.
+			def connection
+				@connection ||= @pool.acquire
+			end
+			
+			# Flush the connection and then return it to the connection pool.
+			def close
+				if @connection
+					@pool.release(@connection)
+					@connection = nil
+				end
+			end
+			
+			def closed?
+				@connection.nil?
+			end
+			
+			def query(fragment = String.new, **parameters)
+				if parameters.empty?
+					Query.new(self, fragment)
+				else
+					Query.new(self).interpolate(fragment, **parameters)
+				end
+			end
+			
+			def clause(fragment = String.new)
+				Query.new(self, fragment)
+			end
+			
 			# Send a query to the server.
 			# @parameter statement [String] The SQL query to send.
 			def call(statement, **options)
@@ -33,7 +73,11 @@ module DB
 				
 				connection.send_query(statement, **options)
 				
-				yield connection if block_given?
+				if block_given?
+					yield connection
+				elsif result = connection.next_result
+					return Records.wrap(result)
+				end
 			end
 		end
 	end

--- a/lib/db/query.rb
+++ b/lib/db/query.rb
@@ -116,13 +116,7 @@ module DB
 		# Send the query to the remote server to be executed. See {Context::Session#call} for more details.
 		# @returns [Enumerable] The resulting records.
 		def call(&block)
-			if block_given?
-				@context.call(@buffer, &block)
-			else
-				@context.call(@buffer) do |connection|
-					return connection.next_result
-				end
-			end
+			@context.call(@buffer, &block)
 		end
 		
 		def to_s

--- a/lib/db/records.rb
+++ b/lib/db/records.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Copyright, 2020, by Samuel G. D. Williams. <http://www.codeotaku.com>
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+module DB
+	# A buffer of records.
+	class Records
+		EMPTY = self.new.freeze
+		
+		def self.wrap(result)
+			# We want to avoid extra memory allocations when there are no columns:
+			if result.field_count == 0
+				return EMPTY
+			end
+			
+			return self.new(result.field_names, result.to_a)
+		end
+		
+		def initialize(columns, rows)
+			@columns = columns
+			@rows = rows
+		end
+		
+		def freeze
+			return self if frozen?
+			
+			@columns.freeze
+			@rows.freeze
+			
+			super
+		end
+		
+		attr :columns
+		attr :rows
+		
+		def to_a
+			@rows
+		end
+	end
+end

--- a/lib/db/records.rb
+++ b/lib/db/records.rb
@@ -23,12 +23,10 @@
 module DB
 	# A buffer of records.
 	class Records
-		EMPTY = self.new.freeze
-		
 		def self.wrap(result)
 			# We want to avoid extra memory allocations when there are no columns:
-			if result.field_count == 0
-				return EMPTY
+			if result.field_count == 0 || result.row_count == 0
+				return nil
 			end
 			
 			return self.new(result.field_names, result.to_a)


### PR DESCRIPTION
## Description

As discussed in https://github.com/socketry/db-mariadb/issues/1

`Session#call` without a block currently returns `nil`. This change restores past behaviour by buffering the result into a a generic `DB::Records` object. It's not possible to do this correctly as not all database results are buffered - i.e. reading the results might wait for more data from the network.

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
